### PR TITLE
Added fix for mac os

### DIFF
--- a/src/init-project.js
+++ b/src/init-project.js
@@ -109,7 +109,7 @@ module.exports = {
             '-e', `s|@@author@@|${args.author}|`,
             '-e', `s|@@license@@|${args.license}|`,
             path.resolve(args.output_dir, 'package.json')]);
-            await execCommand(['rm', path.resolve(args.output_dir, 'package.json.backup')])
+            await execCommand(['rm', path.resolve(args.output_dir, 'package.json.backup')]);
         }
         else {
             await execCommand(['sed', '-i',
@@ -119,7 +119,7 @@ module.exports = {
             '-e', `s|@@license@@|${args.license}|`,
             path.resolve(args.output_dir, 'package.json')]);
         }
-        
+
         const licenseFD = await util.promisify(fs.open)(path.resolve(args.output_dir, 'LICENSE'), 'w');
         await execCommand(['licejs',
             '-o', args.author,

--- a/src/init-project.js
+++ b/src/init-project.js
@@ -102,13 +102,24 @@ module.exports = {
         if (args.developer_key)
             await execCommand(['git', 'config', 'thingpedia.developer-key', args.developer_key], { cwd: args.output_dir });
 
-        await execCommand(['sed', '-i',
+        if (process.platform === 'darwin') {
+            await execCommand(['sed', '-i', '.backup',
             '-e', `s|@@name@@|${name}|`,
             '-e', `s|@@description@@|${args.description}|`,
             '-e', `s|@@author@@|${args.author}|`,
             '-e', `s|@@license@@|${args.license}|`,
             path.resolve(args.output_dir, 'package.json')]);
-
+            await execCommand(['rm', path.resolve(args.output_dir, 'package.json.backup')])
+        }
+        else {
+            await execCommand(['sed', '-i',
+            '-e', `s|@@name@@|${name}|`,
+            '-e', `s|@@description@@|${args.description}|`,
+            '-e', `s|@@author@@|${args.author}|`,
+            '-e', `s|@@license@@|${args.license}|`,
+            path.resolve(args.output_dir, 'package.json')]);
+        }
+        
         const licenseFD = await util.promisify(fs.open)(path.resolve(args.output_dir, 'LICENSE'), 'w');
         await execCommand(['licejs',
             '-o', args.author,


### PR DESCRIPTION
Need to execute `rm` after that to remove backup file, somehow when in mac, doing `-i ''` causes `package.json''` to be generated instead