### PR TITLE
Avoid depending on a too-recent version of git

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -26,15 +26,15 @@ const util = require('util');
 
 async function get(key, _default) {
     try {
-        const args = ['config', '--get', '--default', _default || '', key];
+        const args = ['config', '--get', key];
         const { stdout, stderr } = await util.promisify(child_process.execFile)('git', args);
         process.stderr.write(stderr);
         return stdout.trim() || _default;
     } catch(e) {
         // ignore error if git is not installed
-        if (e.code !== 'ENOENT')
+        // also ignore error if the key is not present
+        if (e.code !== 'ENOENT' && e.code !== 1)
             throw e;
-        // also ignore error if the key
         return _default;
     }
 }


### PR DESCRIPTION
Older versions of git don't support "--default". Notably, those
older versions are the default in Ubuntu 18.04 and RHEL 7, which
are still in active use.

Fixes #50 